### PR TITLE
Correct version number and release date

### DIFF
--- a/net.sourceforge.wxEDID.appdata.xml
+++ b/net.sourceforge.wxEDID.appdata.xml
@@ -41,6 +41,6 @@
   </provides>
 
   <releases>
-    <release version="32.0.0.465" date="2020-12-08"/>
+    <release version="0.0.29" date="2023-05-22"/>
   </releases>
 </component>


### PR DESCRIPTION
For some reason flathub.org and KDE discover think this is 32.0.0.465 from 3 years ago.  There has never been a 32.0.0.465.  Searching the web suggests there was a version of Adobe Flash Player that used that number, and the line seems to have been copied [from com.adobe.Flash-Player-Projector](https://github.com/flathub/com.adobe.Flash-Player-Projector/blob/b24bb681aee3aaca516304822f044107e2c33eed/com.adobe.Flash-Player-Projector.appdata.xml#L40).